### PR TITLE
Fix token too long error

### DIFF
--- a/service/hostapi/stats/container_stats.go
+++ b/service/hostapi/stats/container_stats.go
@@ -1,7 +1,6 @@
 package stats
 
 import (
-	"bufio"
 	"io"
 	"net/url"
 	"time"
@@ -74,21 +73,8 @@ func (s *ContainerStatsHandler) Handle(key string, initialMessage string, incomi
 		}
 	}(writer)
 
-	go func(r *io.PipeReader) {
-		scanner := bufio.NewScanner(r)
-		for scanner.Scan() {
-			text := scanner.Text()
-			message := common.Message{
-				Key:  key,
-				Type: common.Body,
-				Body: text,
-			}
-			response <- message
-		}
-		if err := scanner.Err(); err != nil {
-			log.Errorf("Error with the container stat scanner. error=%v", err)
-		}
-	}(reader)
+	go writeResponseFromPipe(reader, key, response)
+
 	memLimit, err := getMemCapcity()
 	if err != nil {
 		log.Errorf("Error getting memory capacity. id=%v error=%v", id, err)

--- a/service/hostapi/stats/host_stats.go
+++ b/service/hostapi/stats/host_stats.go
@@ -1,7 +1,6 @@
 package stats
 
 import (
-	"bufio"
 	"io"
 	"net/url"
 	"time"
@@ -51,21 +50,7 @@ func (s *HostStatsHandler) Handle(key string, initialMessage string, incomingMes
 		}
 	}(writer)
 
-	go func(r *io.PipeReader) {
-		scanner := bufio.NewScanner(r)
-		for scanner.Scan() {
-			text := scanner.Text()
-			message := common.Message{
-				Key:  key,
-				Type: common.Body,
-				Body: text,
-			}
-			response <- message
-		}
-		if err := scanner.Err(); err != nil {
-			log.Errorf("Error with the container stat scanner. error=%v", err)
-		}
-	}(reader)
+	go writeResponseFromPipe(reader, key, response)
 
 	memLimit, err := getMemCapcity()
 	if err != nil {

--- a/service/hostapi/stats/stats.go
+++ b/service/hostapi/stats/stats.go
@@ -1,7 +1,6 @@
 package stats
 
 import (
-	"bufio"
 	"io"
 	"net/url"
 	"time"
@@ -49,21 +48,7 @@ func (s *Handler) Handle(key string, initialMessage string, incomingMessages <-c
 		}
 	}(writer)
 
-	go func(r *io.PipeReader) {
-		scanner := bufio.NewScanner(r)
-		for scanner.Scan() {
-			text := scanner.Text()
-			message := common.Message{
-				Key:  key,
-				Type: common.Body,
-				Body: text,
-			}
-			response <- message
-		}
-		if err := scanner.Err(); err != nil {
-			log.Errorf("Error with the container stat scanner. error=%v", err)
-		}
-	}(reader)
+	go writeResponseFromPipe(reader, key, response)
 
 	memLimit, err := getMemCapcity()
 	if err != nil {


### PR DESCRIPTION
Problem:
Fail to get stats if a node has plenty of containers.
To reproduce, create a nginx service with 100 containers in a single node environment, go to the node detail page, and the container stats fail to show.

Solution:
Substitute bufio.Scanner with bufio.Reader. 